### PR TITLE
Fuzzy match capture to reference images

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,11 +65,21 @@ class Board():
 			image_name = os.fsdecode(image_os)
 			image = Image.open(CARD_IMAGES + image_os).convert('RGB')
 
-			if list(image.getdata()) == list(capture.getdata()):
+			deltas = [
+				abs(i[x] - c[x])
+				for i, c in zip(image.getdata(), capture.getdata())
+				for x in (0, 1, 2)
+			]
+
+			if all(d < 2 for d in deltas):
 				card_value = image_name[0]
 				card_suit = image_name[1]
 
 				return Card(card_value, card_suit)
+		else:
+			capture.save("unmatched_capture.png")
+			raise RuntimeError("get_card failed for captured image. Capture saved to umatched_capture.png")
+
 	def make_game(self):
 		rank_cards = []
 		for rank_idx in range(len(self.bounding_box_list)):


### PR DESCRIPTION
This is a really cool project!

I noticed on my setup (Steam, 4K monitor running at non-native 1920x1080, game fullscreened), for no apparent reason the captured image rgb values would occasionally differ by exactly one from the reference images, eg (237, 105, 10) in the capture vs (236, 105, 10) in the reference.

I was able to hack around this by considering the capture a match provided all three values in each rgb triplet were within 1 of the reference image. Once I made this change everything worked as expected.

Feel free to decline this PR as it may just be a peculiarity of my settings; I just wanted to submit a heads-up in case anyone else runs into similar issues.